### PR TITLE
## 1.2.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,12 @@
     "version": "0.2.0",
     "configurations": [ 
         {
+            "name": "custom read example",
+            "request": "launch",
+            "type": "dart",
+            "program": "example\\custom_request_example.dart"
+        },
+        {
             "name": "read example",
             "request": "launch",
             "type": "dart",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.0
+- Changed 'ModbusFunctionCode' from enum to class in order to add custom types
+- Changed 'ModbusElementType' from enum to class in order to add custom types
+- Added 'custom_request_example.dart' example
+- Changed ModbusRequest:
+  - 'protocolDataUnit' is now a getter and no more a final variable
+  - 'functionCode' is now of type 'FunctionCode'
+
 ## 1.1.2
 - Added 'ModbusFileMultipleRecord' class
 - Bug fix in response error code handling

--- a/example/custom_request_example.dart
+++ b/example/custom_request_example.dart
@@ -1,0 +1,39 @@
+import 'package:logging/logging.dart';
+import 'package:modbus_client/modbus_client.dart';
+import 'package:modbus_client_tcp/modbus_client_tcp.dart';
+
+void main() async {
+  // Simple modbus logging
+  ModbusAppLogger(Level.FINE);
+
+  // Create your own element type by defining your custom read & write function codes
+  ModbusElementType myCustomType = ModbusElementType(
+      ModbusFunctionCode(0x04, FunctionType.read),
+      ModbusFunctionCode(0x06, FunctionType.writeSingle),
+      ModbusFunctionCode(0x10, FunctionType.writeMultiple));
+
+  // Create a modbus int16 register element
+  var batteryTemperature = ModbusInt16Register(
+      name: "BatteryTemperature",
+      type: myCustomType,
+      address: 22,
+      uom: "°C",
+      multiplier: 0.1,
+      onUpdate: (self) => print(self));
+
+  // Discover the Modbus server
+  var serverIp = await ModbusClientTcp.discover("192.168.8.106");
+  if (serverIp == null) {
+    ModbusAppLogger.shout("No modbus server found!");
+    return;
+  }
+
+  // Create the modbus client.
+  var modbusClient = ModbusClientTcp(serverIp, unitId: 1);
+
+  // Send a read request from the element
+  await modbusClient.send(batteryTemperature.getReadRequest());
+
+  // Ending here
+  modbusClient.disconnect();
+}

--- a/lib/modbus_client.dart
+++ b/lib/modbus_client.dart
@@ -7,46 +7,58 @@ export 'src/modbus_element_group.dart';
 export 'src/modbus_app_logger.dart';
 export 'src/modbus_file_record.dart';
 
+enum FunctionType { read, writeSingle, writeMultiple, custom }
+
+abstract class FunctionCode {
+  int get code;
+  FunctionType get type;
+}
+
 /// The Modbus standard function codes.
-enum ModbusFunctionCode {
-  readCoils(0x01),
-  readDiscreteInputs(0x02),
-  readHoldingRegisters(0x03),
-  readInputRegisters(0x04),
-  writeSingleCoil(0x05),
-  writeSingleHoldingRegister(0x06),
-  writeMultipleCoils(0x0F),
-  writeMultipleHoldingRegisters(0x10);
+class ModbusFunctionCode implements FunctionCode {
+  static const ModbusFunctionCode readCoils =
+      ModbusFunctionCode(0x01, FunctionType.read);
+  static const ModbusFunctionCode readDiscreteInputs =
+      ModbusFunctionCode(0x02, FunctionType.read);
+  static const ModbusFunctionCode readHoldingRegisters =
+      ModbusFunctionCode(0x03, FunctionType.read);
+  static const ModbusFunctionCode readInputRegisters =
+      ModbusFunctionCode(0x04, FunctionType.read);
+  static const ModbusFunctionCode writeSingleCoil =
+      ModbusFunctionCode(0x05, FunctionType.writeSingle);
+  static const ModbusFunctionCode writeSingleHoldingRegister =
+      ModbusFunctionCode(0x06, FunctionType.writeSingle);
+  static const ModbusFunctionCode writeMultipleCoils =
+      ModbusFunctionCode(0x0F, FunctionType.writeMultiple);
+  static const ModbusFunctionCode writeMultipleHoldingRegisters =
+      ModbusFunctionCode(0x10, FunctionType.writeMultiple);
 
-  const ModbusFunctionCode(this.code);
+  @override
   final int code;
+  @override
+  final FunctionType type;
 
-  bool get isRead => isReadFunction(code);
-  bool get isWrite => isWriteFunction(code);
-  bool get isWriteSingle => isWriteSingleFunction(code);
-  bool get isWriteMultiple => isWriteMultipleFunction(code);
-
-  static bool isReadFunction(code) => 0x00 < code && code <= 0x04;
-  static bool isWriteFunction(code) => 0x04 < code && code <= 0x10;
-  static bool isWriteSingleFunction(code) => code == 0x05 || code == 0x06;
-  static bool isWriteMultipleFunction(code) => code == 0x0F || code == 0x10;
-  static bool isSpecialFunction(code) => code > 0x10;
+  const ModbusFunctionCode(this.code, this.type);
 }
 
 /// The Modbus element types.
-enum ModbusElementType {
+class ModbusElementType {
   /// Single bit [Read-Only]
-  discreteInput(ModbusFunctionCode.readDiscreteInputs),
+  static const ModbusElementType discreteInput =
+      ModbusElementType(ModbusFunctionCode.readDiscreteInputs);
 
   /// Single bit [Read-Write]
-  coil(ModbusFunctionCode.readCoils, ModbusFunctionCode.writeSingleCoil,
-      ModbusFunctionCode.writeMultipleCoils),
+  static const ModbusElementType coil = ModbusElementType(
+      ModbusFunctionCode.readCoils,
+      ModbusFunctionCode.writeSingleCoil,
+      ModbusFunctionCode.writeMultipleCoils);
 
   /// 16-bit word [Read-Only]
-  inputRegister(ModbusFunctionCode.readInputRegisters),
+  static const ModbusElementType inputRegister =
+      ModbusElementType(ModbusFunctionCode.readInputRegisters);
 
   /// 16-bit word [Read-Write]
-  holdingRegister(
+  static const ModbusElementType holdingRegister = ModbusElementType(
       ModbusFunctionCode.readHoldingRegisters,
       ModbusFunctionCode.writeSingleHoldingRegister,
       ModbusFunctionCode.writeMultipleHoldingRegisters);
@@ -54,9 +66,9 @@ enum ModbusElementType {
   const ModbusElementType(this.readFunction,
       [this.writeSingleFunction, this.writeMultipleFunction]);
 
-  final ModbusFunctionCode readFunction;
-  final ModbusFunctionCode? writeSingleFunction;
-  final ModbusFunctionCode? writeMultipleFunction;
+  final FunctionCode readFunction;
+  final FunctionCode? writeSingleFunction;
+  final FunctionCode? writeMultipleFunction;
 
   /// True if the element type represents a registry type
   bool get isRegister =>

--- a/lib/src/element_type/modbus_element_num.dart
+++ b/lib/src/element_type/modbus_element_num.dart
@@ -62,7 +62,7 @@ abstract class ModbusNumRegister<T extends num> extends ModbusElement<T> {
       ..setUint16(3, 2) // value register count
       ..setUint8(5, 4) // value byte count
       ..setUint32(6, rawValue ? value : _getRawValue(value));
-    return ModbusWriteRequest(this, pdu,
+    return ModbusWriteRequest(this, pdu, type.writeMultipleFunction!,
         unitId: unitId, responseTimeout: responseTimeout);
   }
 

--- a/lib/src/modbus_element.dart
+++ b/lib/src/modbus_element.dart
@@ -49,7 +49,7 @@ abstract class ModbusElement<T> {
       ..setUint8(0, type.readFunction.code)
       ..setUint16(1, address)
       ..setUint16(3, byteCount > 1 ? byteCount ~/ 2 : 1);
-    return ModbusReadRequest(this, pdu,
+    return ModbusReadRequest(this, pdu, type.readFunction,
         unitId: unitId, responseTimeout: responseTimeout);
   }
 
@@ -70,7 +70,7 @@ abstract class ModbusElement<T> {
       ..setUint8(0, type.writeSingleFunction!.code)
       ..setUint16(1, address)
       ..setUint16(3, rawValue ? value as int : _getRawValue(value));
-    return ModbusWriteRequest(this, pdu,
+    return ModbusWriteRequest(this, pdu, type.writeSingleFunction!,
         unitId: unitId, responseTimeout: responseTimeout);
   }
 

--- a/lib/src/modbus_element_group.dart
+++ b/lib/src/modbus_element_group.dart
@@ -54,7 +54,7 @@ class ModbusElementsGroup extends Iterable<ModbusElement> {
       ..setUint8(0, _type!.readFunction.code)
       ..setUint16(1, _startAddress)
       ..setUint16(3, _addressRange);
-    return ModbusReadGroupRequest(this, pdu,
+    return ModbusReadGroupRequest(this, pdu, _type!.readFunction,
         unitId: unitId, responseTimeout: responseTimeout);
   }
 

--- a/lib/src/modbus_file_record.dart
+++ b/lib/src/modbus_file_record.dart
@@ -285,13 +285,20 @@ class ModbusFileDoubleRecord extends ModbusFileRecord {
 class ModbusFileRecordsReadRequest extends ModbusRequest {
   final List<ModbusFileRecord> fileRecords;
 
+  static FunctionCode recordsReadFunctionCode =
+      ModbusFunctionCode(0x14, FunctionType.custom);
+  @override
+  final FunctionCode functionCode = recordsReadFunctionCode;
+  @override
+  Uint8List get protocolDataUnit => _getProtocolDataUnit(fileRecords);
+
   @override
   final int responsePduLength;
 
   ModbusFileRecordsReadRequest(this.fileRecords,
       {super.unitId, super.responseTimeout})
       : responsePduLength = _getResponsePduLength(fileRecords),
-        super(_getProtocolDataUnit(fileRecords));
+        super();
 
   static int _getResponsePduLength(List<ModbusFileRecord> fileRecords) {
     int len = 2;
@@ -324,7 +331,7 @@ class ModbusFileRecordsReadRequest extends ModbusRequest {
     // Sub-Req. x+1, ...
     var protocolDataUnit = Uint8List(2 + 7 * fileRecords.length);
     int i = 0;
-    protocolDataUnit[i++] = 0x14;
+    protocolDataUnit[i++] = recordsReadFunctionCode.code;
     protocolDataUnit[i++] = 7 * fileRecords.length;
     for (var record in fileRecords) {
       protocolDataUnit[i++] = 6; // Reference type
@@ -339,8 +346,7 @@ class ModbusFileRecordsReadRequest extends ModbusRequest {
   }
 
   @override
-  ModbusResponseCode internalSetFromPduResponse(
-      int functionCode, Uint8List pdu) {
+  ModbusResponseCode internalSetFromPduResponse(Uint8List pdu) {
     // Response
     // --------
     // Function code 1 Byte 0x14
@@ -349,7 +355,7 @@ class ModbusFileRecordsReadRequest extends ModbusRequest {
     // Sub-Req. x, Reference Type 1 Byte 6
     // Sub-Req. x, Record Data N x 2 Bytes
     // Sub-Req. x+1, ...
-    if (pdu.length != responsePduLength || pdu[0] != functionCode) {
+    if (pdu.length != responsePduLength || pdu[0] != functionCode.code) {
       return ModbusResponseCode.requestRxFailed;
     }
     int i = 2;
@@ -374,13 +380,20 @@ class ModbusFileRecordsReadRequest extends ModbusRequest {
 class ModbusFileRecordsWriteRequest extends ModbusRequest {
   final List<ModbusFileRecord> fileRecords;
 
+  static FunctionCode recordsWriteFunctionCode =
+      ModbusFunctionCode(0x15, FunctionType.custom);
+  @override
+  final FunctionCode functionCode = recordsWriteFunctionCode;
+  @override
+  Uint8List get protocolDataUnit => _getProtocolDataUnit(fileRecords);
+
   @override
   final int responsePduLength;
 
   ModbusFileRecordsWriteRequest(this.fileRecords,
       {super.unitId, super.responseTimeout})
       : responsePduLength = _getResponsePduLength(fileRecords),
-        super(_getProtocolDataUnit(fileRecords));
+        super();
 
   static int _getResponsePduLength(List<ModbusFileRecord> fileRecords) {
     int len = 2;
@@ -415,7 +428,7 @@ class ModbusFileRecordsWriteRequest extends ModbusRequest {
     int reqDataLength = _getResponsePduLength(fileRecords) - 2;
     var protocolDataUnit = Uint8List(2 + reqDataLength);
     int i = 0;
-    protocolDataUnit[i++] = 0x15;
+    protocolDataUnit[i++] = recordsWriteFunctionCode.code;
     protocolDataUnit[i++] = reqDataLength;
     for (var record in fileRecords) {
       protocolDataUnit[i++] = 6; // Reference type
@@ -435,8 +448,7 @@ class ModbusFileRecordsWriteRequest extends ModbusRequest {
   }
 
   @override
-  ModbusResponseCode internalSetFromPduResponse(
-      int functionCode, Uint8List pdu) {
+  ModbusResponseCode internalSetFromPduResponse(Uint8List pdu) {
     // Response is echo of request
     return ModbusResponseCode.requestSucceed;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: modbus_client
 description: This is the base Modbus Client package sending requests to a remote device (i.e. Modbus Server) via Serial (ASCII and RTU) or TCP/IP connection.
-version: 1.1.2
+version: 1.2.0
 repository: https://github.com/cabbi/modbus_client
 
 environment:
@@ -13,5 +13,5 @@ dependencies:
 dev_dependencies:
   lints: ^3.0.0
   test: ^1.21.0
-  modbus_client_tcp: ^1.0.2
-  modbus_client_serial: ^1.0.0
+  modbus_client_tcp: ^1.0.7
+  modbus_client_serial: ^1.0.3


### PR DESCRIPTION
- Changed 'ModbusFunctionCode' from enum to class in order to add custom types
- Changed 'ModbusElementType' from enum to class in order to add custom types
- Added 'custom_request_example.dart' example
- Changed ModbusRequest:
  - 'protocolDataUnit' is now a getter and no more a final variable
  - 'functionCode' is now of type 'FunctionCode'